### PR TITLE
style: Include docstring typos fixes generated by codespell

### DIFF
--- a/nwb_docutils/doctools/render.py
+++ b/nwb_docutils/doctools/render.py
@@ -492,7 +492,7 @@ class NXGraphHierarchyDescription(object):
     def suggest_xlim(self):
         """
         Suggest xlimits for plotting
-        :return: Tupple with min/max x values
+        :return: Tuple with min/max x values
         """
         import numpy as np
 
@@ -507,7 +507,7 @@ class NXGraphHierarchyDescription(object):
     def suggest_ylim(self):
         """
         Suggest ylimits for plotting
-        :return: Tupple with min/max x values
+        :return: Tuple with min/max x values
         """
         import numpy as np
 
@@ -572,11 +572,11 @@ class NXGraphHierarchyDescription(object):
         :param show_labels: Boolean indicating whether we should show the names of the nodes
         :param relationship_types: List of edge types that should be rendered. If None, then all edges will be rendered.
         :param figsize: The size of the matplotlib figure
-        :param label_offset: Offsets for the node lables. This may be either: i) None (default),
+        :param label_offset: Offsets for the node labels. This may be either: i) None (default),
                    ii) Tuple with constant (x,y) offset for the text labels, or
                    iii) Dict of tuples where the keys are the names of the nodes for which labels should be moved
                         and the values are the (x,y) offsets for the given nodes.
-        :param label_font_size: Font size for the lables
+        :param label_font_size: Font size for the labels
         :param xlim: The x limits to be used for the plot
         :param ylim: The y limits to be used for the plot
         :param legend_location: The legend location (e.g., 'upper left' , 'lower right')
@@ -601,7 +601,7 @@ class NXGraphHierarchyDescription(object):
             for relationship edges. This may also be a dict of per-relationship-typ alpha values, similar
             to relationship_colors.
         :param node_colors: Dict with the color strings of the different node types. This may also be a single
-                string in case that the same color should be used for all node types. Defaul behavior is:
+                string in case that the same color should be used for all node types. Default behavior is:
 
                 ```{'typed_dataset': 'blue',
                     'untyped_dataset': 'lightblue',
@@ -743,7 +743,7 @@ class NXGraphHierarchyDescription(object):
             labels = {i: os.path.basename(i) if len(os.path.basename(i)) > 0 else i for i in graph.nodes(data=False)}
             # Determine label positions
             if label_offset is not None:
-                # Move individual lables by the user-defined offsets
+                # Move individual labels by the user-defined offsets
                 if isinstance(label_offset, dict):
                     label_pos = deepcopy(pos)
                     for k, v in label_offset.items():

--- a/nwb_docutils/doctools/renderrst.py
+++ b/nwb_docutils/doctools/renderrst.py
@@ -1,5 +1,5 @@
 """
-Module with helper functions to render hdfm.spec format specfications to
+Module with helper functions to render hdfm.spec format specifications to
 RST documents.
 """
 from hdmf.spec.spec import GroupSpec, DatasetSpec, LinkSpec, AttributeSpec, RefSpec
@@ -299,7 +299,7 @@ class SpecToRST(object):
         :type show_yaml_src" bool
         :param file_dir: Directory where output RST docs should be stored. Required if file_per_type is True.
         :type file_dir: str or None
-        :param file_per_type: Generate a seperate rst files for each data_type and include them
+        :param file_per_type: Generate a separate rst files for each data_type and include them
                               in the src_doc and desc_doc (True). If set to False then write the
                               contents to src_doc and desc_doc directly.
         :type file_per_type: book
@@ -450,7 +450,7 @@ class SpecToRST(object):
         :param target_doc: Target RST document where the type hierarchy should be rendered to or None if a new document
                            should be created.
         :type target_doc: RSTDocument or Non
-        :param section_label: String with the label for the section (or None if no label should be addded)
+        :param section_label: String with the label for the section (or None if no label should be added)
         :param subsection_title: String with the title for the secton (or None if no section should be added)
 
         :returns: Tuple with: 1) RSTDocument with the type hierarchy,
@@ -664,7 +664,7 @@ class SpecToRST(object):
             # Create the description for the object
             spec_doc = SpecToRST.clean_schema_doc_string(doc_str=spec.doc,
                                                          add_prefix=rst_table.newline + rst_table.newline)
-            # Create the list of additonal object properties to be added as a list ot the doc
+            # Create the list of additional object properties to be added as a list ot the doc
             spec_doc += SpecToRST.render_specification_properties(spec=spec,
                                                                   newline=rst_table.newline,
                                                                   ignore_props=['primitive_type'])
@@ -740,7 +740,7 @@ class SpecToRST(object):
         :param appreviate_main_object_doc:  Abbreviate the documentation of the main object for which a table
                         is rendered in the table. This is commonly set to True as doc of the main object is already
                         rendered as the main intro for the section describing the object
-        :param show_subgroups_in_seperate_table: Should top-level subgroups be listed in a seperate table or as part
+        :param show_subgroups_in_seperate_table: Should top-level subgroups be listed in a separate table or as part
                         of the main dataset and attributes table
         :param sectype: The kind of section to be used for rendering the group spec. Allowable values are
                         'par' for paragraph, 'sec' for section, 'chp' for chapter, 'subsec' for subsection,

--- a/nwb_docutils/doctools/rst.py
+++ b/nwb_docutils/doctools/rst.py
@@ -14,7 +14,7 @@ class RSTDocument(object):
     ALIGN = ['top', 'middle', 'bottom', 'left', 'center', 'right']
 
     def __init__(self):
-        """Initalize empty RST document"""
+        """Initialize empty RST document"""
         self.document = ""
         self.newline = "\n"
         self.default_indent = '    '
@@ -60,8 +60,8 @@ class RSTDocument(object):
 
     def add_label(self, label):
         """
-        Add a section lable
-        :param label: name of the lable
+        Add a section label
+        :param label: name of the label
         """
         self.document += ".. _%s:" % label
         self.document += self.newline + self.newline
@@ -70,7 +70,7 @@ class RSTDocument(object):
     def get_reference(label, link_title=None):
         """
         Get RST text to create a reference to the given label
-        :param label: Name of the lable to link to
+        :param label: Name of the label to link to
         :param link_title: Text for the link
         :return: String with the inline reference text
         """
@@ -368,7 +368,7 @@ class RSTSectionLabelHelper(object):
     @staticmethod
     def get_section_label(neurodata_type):
         """
-        Get the label of the section with the documenation for the given neurodata_type
+        Get the label of the section with the documentation for the given neurodata_type
 
         :param neurodata_type: String with the name of the neurodata_type
         :return: String with the section label where the neurodatatype is described
@@ -420,7 +420,7 @@ class RSTTable(object):
 
     def __init__(self, cols):
         """
-        Initalize the RSTTable
+        Initialize the RSTTable
 
         :param cols: List of strings with the column labels. Or int with the number of columns
         """

--- a/nwb_docutils/generate_format_docs.py
+++ b/nwb_docutils/generate_format_docs.py
@@ -106,7 +106,7 @@ def load_namespace(namespace_file,
     :param default_namespace: String with the name of the default namespace
     :param resolve: Bool indicating whether the type inclusions should be resolved in the namespace
     :param default_type_map: The default TypeMap to be used for loading namespaces. This is useful, e.g., when we have
-                             an API (e.g., PyNWB) where we have type mape that we want to extend/reuse.
+                             an API (e.g., PyNWB) where we have type map that we want to extend/reuse.
 
     :return: NamespaceCatalog
     """
@@ -151,7 +151,7 @@ def render_data_type_section(section,
     :param file_dir: Directory where figures and outpy RST docs should be stored
     :param show_hierarchy_plots: Create figures showing the hierarchy defined by the spec
     :param show_yaml_src: Boolean indicating that we should render the YAML source in the src_doc
-    :param file_per_type: Generate a seperate rst files for each data_type and include them
+    :param file_per_type: Generate a separate rst files for each data_type and include them
                           in the src_doc and desc_doc (True). If set to False then write the
                           contents to src_doc and desc_doc directly.
     :param print_status: Bool indicating whether to print progress and debugging messages to standard out
@@ -309,7 +309,7 @@ def render_data_type_section(section,
         ####################################################################
         #  Add the YAML sources to the document if requested
         ####################################################################
-        # If the YAML are shown in a seperate chapter than add section headings
+        # If the YAML are shown in a separate chapter than add section headings
         if seperate_src_file:
             # Add a section to the file for the sources
             src_sec_lable = LabelHelper.get_src_section_label(rt, spec_generate_src_file, spec_show_yaml_src)
@@ -547,7 +547,7 @@ def main():
         if document is not None and filename is not None:
             document.write(filename=filename, mode=mode)
             PrintHelper.print("Write %s" % filename, PrintHelper.OKGREEN)
-    write_rst_doc(desc_doc, doc_filename)      # Write the descritpion RST document
+    write_rst_doc(desc_doc, doc_filename)      # Write the description RST document
     write_rst_doc(src_doc, srcdoc_filename)    # Write the source RST document
     write_rst_doc(masterdoc, master_filename)  # Write the master RST document
 

--- a/nwb_docutils/init_sphinx_extension_doc.py
+++ b/nwb_docutils/init_sphinx_extension_doc.py
@@ -146,13 +146,13 @@ In addition to standard Sphinx options, there are a number of additional options
 
 * `spec_show_yaml_src` - Boolean indicating whether the YAML sources should be included for the different Neurodata types
 * `spec_generate_src_file` - Boolean indicating whether the YAML sources of the neurodata_types should be rendered in a separate section (True) or in the same location as the main documentation
-* `spec_show_hierarchy_plots` - Boolean indicating whether we should generate and show figures of the hierachy defined by the specifications as part of the documentation
+* `spec_show_hierarchy_plots` - Boolean indicating whether we should generate and show figures of the hierarchy defined by the specifications as part of the documentation
 * `spec_file_per_type` - Boolean indicating whether we should generate separate .inc reStructuredText for each neurodata_type (True)
 or should all text be added to the main file (False)
 * `spec_show_subgroups_in_tables` - Should subgroups of the main groups be rendered in the table as well. Usually this is disabled since groups are rendered as separate sections in the text
 * `spec_appreviate_main_object_doc_in_tables` - Abbreviate the documentation of the main object for which a table is rendered in the table. This is commonly set to True as doc of the main object is already rendered as the main intro for the section describing the object
 * `spec_show_title_for_tables` - Add a title for the table showing the specifications.
-* `spec_show_subgroups_in_seperate_table` - Should top-level subgroups be listed in a seperate table or as part of the main dataset and attributes table
+* `spec_show_subgroups_in_seperate_table` - Should top-level subgroups be listed in a separate table or as part of the main dataset and attributes table
 * `spec_table_depth_char` - Char to be used as prefix to indicate the depth of an object in the specification hierarchy. NOTE: The char used should be supported by LaTeX.
 * `spec_add_latex_clearpage_after_ndt_sections` - Add a LaTeX clearpage after each main section describing a neurodata_type. This helps in LaTeX to keep the ordering of figures, tables, and code blocks consistent in particular when the hierarchy_plots are included.
 * `spec_resolve_type_inc` - Resolve includes to always show the full list of objects that are part of a type (True) or to show only the parts that are actually new to a current type while only linking to base types (False)
@@ -487,7 +487,7 @@ spec_generate_src_file = %s
 # or should all text be added to the main file
 spec_file_per_type = %s
 
-# Should top-level subgroups be listed in a seperate table or as part of the main dataset and attributes table
+# Should top-level subgroups be listed in a separate table or as part of the main dataset and attributes table
 spec_show_subgroups_in_seperate_table = %s
 
 # Abbreviate the documentation of the main object for which a table is rendered in the table.
@@ -573,7 +573,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 help:
 	@echo "To update documentation sources from the format specification please use \`make apidoc'"
 	@echo ""
-	@echo "To build the documenation please use \`make <target>' where <target> is one of"
+	@echo "To build the documentation please use \`make <target>' where <target> is one of"
 	@echo "  fulldoc    to rebuild the apidoc, html, and latexpdf all at once"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
@@ -743,7 +743,7 @@ def define_cl_args():
     :return: argparse.ArgumentParser
     """
 
-    parser = argparse.ArgumentParser(description='Create format specification SPHINX documenation for an NWB extension.',
+    parser = argparse.ArgumentParser(description='Create format specification SPHINX documentation for an NWB extension.',
                                      add_help=True,
                                      epilog="\n Copyright: Lawrence Berkeley National Laboratory: 2017",
                                      formatter_class=RawDescriptionDefaultHelpArgParseFormatter)
@@ -790,15 +790,15 @@ def define_cl_args():
     parser.add_argument('--latex_clearpage_after_type', dest='latex_clearpage_after_type', action='store', type=bool_type, required=False, default=True,
                         help="Add clearpage command in latex after each neurodata_type to esnure figures always appear in the right section at the cost of adding empty space between sections.")
     parser.add_argument('--table_depth_char', dest='table_depth_char', action='store', type=str, required=False, default='.',
-                        help="Char to be used to indent entries in desciption tables to indicate the depth of the object.")
+                        help="Char to be used to indent entries in description tables to indicate the depth of the object.")
     parser.add_argument('--abbrv_main_obj_in_table', dest='abbrv_main_obj_in_table', action='store', type=bool_type, required=False, default=True,
                         help="Appreviate the description of the main object in the description tables?")
     parser.add_argument('--subgroups_in_seperate_table', dest='subgroups_in_seperate_table', action='store', type=bool_type, required=False, default=True,
-                        help="Render the description of top level subgroups in seperate tables rather than as part of the attributes/dataset table?.")
+                        help="Render the description of top level subgroups in separate tables rather than as part of the attributes/dataset table?.")
     parser.add_argument('--generate_file_per_type', dest='generate_file_per_type', action='store', type=bool_type, required=False, default=True,
                         help="Generate separate reStructuredText files with .inc ending for each type/neurodata_type rather than rendering all description in a single file?")
     parser.add_argument('--generate_src_file', dest='generate_src_file', action='store', type=bool_type, required=False, default=True,
-                        help="Generate seperate reStructuredText files for the YAML sources rather than including them in the desription files?")
+                        help="Generate separate reStructuredText files for the YAML sources rather than including them in the description files?")
     parser.add_argument('--show_hierarchy_plots', dest='show_hierarchy_plots', action='store', type=bool_type, required=False, default=True,
                         help="Generate and show plots of the hierarchy for each tyep/neurodata_type?")
     parser.add_argument('--show_yaml_src', dest='show_yaml_src', action='store', type=bool_type, required=False, default=True,

--- a/versioneer.py
+++ b/versioneer.py
@@ -180,7 +180,7 @@ two common reasons why `setup.py` might not be in the root:
   `setup.cfg`, and `tox.ini`. Projects like these produce multiple PyPI
   distributions (and upload multiple independently-installable tarballs).
 * Source trees whose main purpose is to contain a C library, but which also
-  provide bindings to Python (and perhaps other langauges) in subdirectories.
+  provide bindings to Python (and perhaps other languages) in subdirectories.
 
 Versioneer will look for `.git` in parent directories, and most operations
 should get the right version string. However `pip` and `setuptools` have bugs


### PR DESCRIPTION
This commit was crafted using command like this one:

```
  cd nwb-docutils
  codespell $(find . \( -path ./.git -o -path ./.svn \) -prune -o -type f -print) -x ./nwb_docutils/compare-hdf5-files.ipynb -w
```