### PR TITLE
Fix building of nwb-schema documentation

### DIFF
--- a/nwb_docutils/doctools/renderrst.py
+++ b/nwb_docutils/doctools/renderrst.py
@@ -784,7 +784,7 @@ class SpecToRST(object):
         # Compile the documentation for the group and add it to the RST document
         gdoc = SpecToRST.clean_schema_doc_string(group_spec.doc,
                                                  add_prefix=rst_doc.newline+rst_doc.newline,
-                                                 add_postifix=rst_doc.newline,
+                                                 add_postfix=rst_doc.newline,
                                                  rst_format='**')
         gdoc += rst_doc.newline
         gdoc += SpecToRST.render_specification_properties(group_spec, rst_doc.newline, ignore_props=['primitive_type'])


### PR DESCRIPTION
This commit fixes the following error by addressing a regression introduced
in cddf2b3 (Merge pull request #26 from NeurodataWithoutBorders/fix/postifix):

```pytb
  Traceback (most recent call last):
    File "/home/jcfr/.virtualenvs/nwb/bin/nwb_generate_format_docs", line 11, in <module>
      load_entry_point('nwb-docutils', 'console_scripts', 'nwb_generate_format_docs')()
    File "/home/jcfr/Projects/nwb-docutils/nwb_docutils/generate_format_docs.py", line 542, in main
      print_status=True)
    File "/home/jcfr/Projects/nwb-docutils/nwb_docutils/generate_format_docs.py", line 390, in render_data_type_section
      parent='' if rt != 'NWBFile' else '/')
    File "/home/jcfr/Projects/nwb-docutils/nwb_docutils/doctools/renderrst.py", line 788, in render_group_spec
      rst_format='**')
  TypeError: clean_schema_doc_string() got an unexpected keyword argument 'add_postifix'
  Makefile:175: recipe for target 'apidoc' failed
  make: *** [apidoc] Error 1
```