### PR TITLE
Fix load_namespace when default_type_map is None

### DIFF
--- a/hdmf_docutils/doctools/renderrst.py
+++ b/hdmf_docutils/doctools/renderrst.py
@@ -7,6 +7,7 @@ from .output import PrintHelper
 from collections import OrderedDict
 from .rst import RSTDocument, RSTTable, RSTSectionLabelHelper
 import os
+import warnings
 
 
 class DataTypeSection(dict):
@@ -328,7 +329,17 @@ class SpecToRST(object):
         ns_src_label = "hdmf-type-namespace-src"
         # Create the target doc
         if namespace_name is None:
-            namespace_name = namespace_catalog.default_namespace
+            core = namespace_catalog.core_namespaces
+            if not core:
+                raise ValueError(
+                    "namespace_name not provided and namespace_catalog has no core namespaces"
+                )
+            if len(core) > 1:
+                warnings.warn(
+                    "namespace_name not provided; namespace_catalog has multiple core "
+                    "namespaces %r. Using the first (%r)." % (core, core[0])
+                )
+            namespace_name = core[0]
         curr_namespace = namespace_catalog.get_namespace(namespace_name)
         # Section heading
 

--- a/hdmf_docutils/generate_format_docs.py
+++ b/hdmf_docutils/generate_format_docs.py
@@ -118,10 +118,10 @@ def load_namespace(namespace_file,
             pass
     # Load the namespace separately if it already exists or we don't have a default type map specified
     if namespace_catalog is None:
-        namespace_catalog = NamespaceCatalog(default_namespace,
-                                             group_spec_cls=group_spec_cls,
+        namespace_catalog = NamespaceCatalog(group_spec_cls=group_spec_cls,
                                              dataset_spec_cls=dataset_spec_cls,
-                                             spec_namespace_cls=spec_namespace_cls)
+                                             spec_namespace_cls=spec_namespace_cls,
+                                             core_namespaces=[default_namespace])
         namespace_catalog.load_namespaces(namespace_file, resolve=resolve)
 
     return namespace_catalog


### PR DESCRIPTION
## Summary
- Fixes #94. The `default_type_map=None` branch of `load_namespace` was calling `NamespaceCatalog` with a positional `default_namespace` string and then reading `namespace_catalog.default_namespace`, neither of which `NamespaceCatalog` accepts or exposes. The branch was effectively dead code until nwb-schema PR #663 set `spec_default_type_map = None`, surfacing it on RTD ([build log](https://app.readthedocs.org/projects/nwb-schema/builds/32573738/)).
- `generate_format_docs.load_namespace` now passes `core_namespaces=[default_namespace]` via keyword, matching the actual `NamespaceCatalog` signature.
- `doctools.renderrst.SpecToRST.render_namespace` now falls back to `namespace_catalog.core_namespaces[0]`, raising on empty and warning if more than one core namespace is registered.

This will be released as 0.4.10.

## Test plan
- [x] CI green
- [x] Manually rebuilt `nwb-schema` PR #663 against this branch (hdmf 6.0.1, pynwb dev, hdmf-docutils @ this branch). Confirmed the previous `TypeError: NamespaceCatalog.__init__: incorrect type for 'core_namespaces' (got 'str', expected 'list')` is gone. The build now progresses and fails downstream at `ValueError: Could not load namespace 'hdmf-common'` — `core` declares `hdmf-common` as a dependency and the fresh `NamespaceCatalog` does not pre-load it. Out of scope for this PR; needs a separate fix on the `nwb-schema` side (likely loading `hdmf-common-schema/common/namespace.yaml` before `core`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)